### PR TITLE
Fix background install prompting when Word is not installed on the system

### DIFF
--- a/resource/installer.jsm
+++ b/resource/installer.jsm
@@ -52,11 +52,17 @@ var Plugin = new function() {
 			await installer.run();
 			zoteroPluginInstaller.success();
 		} catch(e) {
-			if(e.toString().indexOf("ExceptionAlreadyDisplayed") !== -1) {
+			const message = e.toString();
+			if (message.includes("ExceptionAlreadyDisplayed")) {
 				Services.prompt.alert(null, this.EXTENSION_STRING,
 					"You cancelled installation of Zotero Word for Mac Integration. To install later, visit the Cite pane in the Zotero preferences.");
 				zoteroPluginInstaller.cancelled();
-			} else {
+			}
+			else if (!zpi.force && message.includes("Word does not appear to be installed on this computer.")) {
+				// Do not display this as an error if not installing via the preferences window
+				zoteroPluginInstaller.success();
+			}
+			else {
 				zoteroPluginInstaller.error("Installation could not be completed because an error occurred.\n\n"+e);
 				throw e;
 			}


### PR DESCRIPTION
Fixes https://github.com/zotero/zotero/issues/4644

@AbeJellinek I don't have quick access to a system with the config where Word was never installed. Could you check if this is good?